### PR TITLE
Add optional callback for applying runtime mod configs

### DIFF
--- a/Libraries/SPTushonka.Server.Web/Models/Configs/ConfigEditorConfigRegistration.cs
+++ b/Libraries/SPTushonka.Server.Web/Models/Configs/ConfigEditorConfigRegistration.cs
@@ -22,6 +22,8 @@ public sealed record ConfigEditorConfigRegistration
 
     public Func<object, CancellationToken, ValueTask>? ApplyToRuntimeAsync { get; init; }
 
+    public Func<object, CancellationToken, ValueTask>? OnAppliedToRuntimeAsync { get; init; }
+
     public static ConfigEditorConfigRegistration Create<TConfig>(
         string id,
         string displayName,

--- a/Libraries/SPTushonka.Server.Web/Services/ConfigEditorService.cs
+++ b/Libraries/SPTushonka.Server.Web/Services/ConfigEditorService.cs
@@ -124,6 +124,11 @@ public class ConfigEditorService
             CopyWritableProperties(editedConfig, runtimeConfig, runtimeType);
         }
 
+        if (descriptor.Registration?.OnAppliedToRuntimeAsync is not null)
+        {
+            await descriptor.Registration.OnAppliedToRuntimeAsync(GetRuntimeConfig(descriptor), CancellationToken.None);
+        }
+
         return Serialize(GetRuntimeConfig(descriptor), runtimeType);
     }
 


### PR DESCRIPTION
Allow mods using the SIC config editor to provide a callback

Use

```namespace DisableTraitorScavs;

using SPTarkov.DI.Annotations;
using SPTarkov.Server.Web.Models.Configs;
using SPTarkov.Server.Web.Services;

[Injectable(InjectionType.Singleton)]
public class ConfigProvider(DstModConfig config) : IConfigEditorConfigProvider
{
    public IEnumerable<ConfigEditorConfigRegistration> GetConfigs()
    {
        var metadata = new ModMetadata();

        yield return ConfigEditorConfigRegistration.Create(
            metadata.ModGuid,
            metadata.Name,
            config,
            Path.Combine("user", "mods", "acidphantasm-disabletraitorscavs", "config.json"
            )
            ) with
            {
                OnAppliedToRuntimeAsync = OnConfigApplied
            };
    }

    private ValueTask OnConfigApplied(object runtimeConfig, CancellationToken cancellationToken)
    {
        Console.WriteLine("Disable Traitor Scavs config applied to runtime!");

        return ValueTask.CompletedTask;
    }
}
```