### PR TITLE
Fix production unlocks from quests getting null traderId

### DIFF
--- a/Libraries/SPTushonka.Server.Core/Utils/Json/StringOrInt.cs
+++ b/Libraries/SPTushonka.Server.Core/Utils/Json/StringOrInt.cs
@@ -35,7 +35,7 @@ public class StringOrInt(string? str, int? num)
 
     public override string? ToString()
     {
-        if (String is null || Int is null)
+        if (String is null && Int is null)
         {
             return null;
         }


### PR DESCRIPTION
Actual fix for the production unlocks, ignore my previous PR fr.

Though the previous commit that added this was to fix profile creation, and I believe this fix also works for that as I created a profile with this code and didn't get any errors but I'm unsure what was being fixed exactly