### PR TITLE
FenceService: Randomize number of keycard uses

### DIFF
--- a/Libraries/SPTushonka.Server.Core/Services/Commerce/FenceService.cs
+++ b/Libraries/SPTushonka.Server.Core/Services/Commerce/FenceService.cs
@@ -930,7 +930,11 @@ public class FenceService(
         }
 
         // Adjust price based on durability
-        if (itemRoot.Upd?.Repairable != null || itemHelper.IsOfBaseclass(itemRoot.Template, BaseClasses.KEY_MECHANICAL))
+        if (
+            itemRoot.Upd?.Repairable != null
+            || itemHelper.IsOfBaseclass(itemRoot.Template, BaseClasses.KEY_MECHANICAL)
+            || itemHelper.IsOfBaseclass(itemRoot.Template, BaseClasses.KEYCARD)
+        )
         {
             var itemQualityModifier = itemHelper.GetItemQualityModifier(itemRoot);
             var basePrice = barterSchemes[itemRoot.Id][0][0].Count;
@@ -1397,8 +1401,14 @@ public class FenceService(
             return;
         }
 
-        // Mechanical key + has limited uses
-        if (itemHelper.IsOfBaseclass(itemDetails.Id, BaseClasses.KEY_MECHANICAL) && (itemDetails.Properties.MaximumNumberOfUsage ?? 0) > 1)
+        // Mechanical key + and keycards have limited uses
+        if (
+            (
+                itemHelper.IsOfBaseclass(itemDetails.Id, BaseClasses.KEY_MECHANICAL)
+                || itemHelper.IsOfBaseclass(itemDetails.Id, BaseClasses.KEYCARD)
+            )
+            && (itemDetails.Properties.MaximumNumberOfUsage ?? 0) > 1
+        )
         {
             itemToAdjust.Upd.Key = new UpdKey
             {


### PR DESCRIPTION
While by default Fence doesn't stock keycards, if a user changes that in SIC or with a mod, those keycards always have full uses. This happened because the code only modified uses for items with `MaximumNumberOfUsage` that had base class of `KEY_MECHANICAL`.

Additionally adds keycards to the price adjustment logic to behave the same way the keys do.

## Some screenshots

Before (note the #11SR key, 130K at 10/10 uses):
<img width="652" height="326" alt="Screenshot 2026-08-21 192645" src="https://github.com/user-attachments/assets/166f539e-2d04-40c6-a342-1c71b973cc1d" />

... and after (now at 104K at 8/10 uses):
<img width="654" height="266" alt="Screenshot 2026-08-21 201113" src="https://github.com/user-attachments/assets/24cc3e4f-3478-4ab7-be5b-a17f462f1798" />
