### PR TITLE
Add guard for invalid session IDs during string conversion, and guard…

### DIFF
--- a/Libraries/SPTushonka.Server.Core/Services/Profile/ProfileActivityService.cs
+++ b/Libraries/SPTushonka.Server.Core/Services/Profile/ProfileActivityService.cs
@@ -94,6 +94,11 @@ public class ProfileActivityService(TimeUtil timeUtil)
 
         foreach (var (sessionId, activeProfile) in _activeProfiles)
         {
+            if (!MongoId.IsValidMongoId(sessionId))
+            {
+                continue;
+            }
+
             // Profile was active in last x minutes, add to return list
             if (currentTimestamp - activeProfile.LastActive < minutes * 60)
             {

--- a/Libraries/SPTushonka.Server.Web/Pages/Status.razor
+++ b/Libraries/SPTushonka.Server.Web/Pages/Status.razor
@@ -83,7 +83,8 @@
         {
             foreach (var activeProfileId in activeProfileIds)
             {
-                _activeProfiles.Add($"{activeProfileId} ({ProfileHelper.GetPmcProfile(activeProfileId).Info.Nickname})");
+                var profileNickname = ProfileHelper.GetPmcProfile(activeProfileId)?.Info?.Nickname ?? L("common-none");
+                _activeProfiles.Add($"{activeProfileId} ({profileNickname})");
             }
         }
 


### PR DESCRIPTION
… null returns on GetPmcProfile / info / nickname


This also stops the NRE throwing when you try to access /status with a miniprofile without a nickname yet. 