### PR TITLE
Add SIC default credential password change prompt + migration

### DIFF
--- a/Libraries/SPTushonka.Server.Core/Models/Spt/Config/HttpConfig.cs
+++ b/Libraries/SPTushonka.Server.Core/Models/Spt/Config/HttpConfig.cs
@@ -75,4 +75,7 @@ public record AuthUserCredential
     /// </summary>
     [JsonPropertyName("isAdministrator")]
     public required bool IsAdministrator { get; set; }
+
+    [JsonPropertyName("mustChangePassword")]
+    public bool? MustChangePassword { get; set; }
 }

--- a/Libraries/SPTushonka.Server.Web/Components/Auth/LoginBox.razor
+++ b/Libraries/SPTushonka.Server.Web/Components/Auth/LoginBox.razor
@@ -1,6 +1,8 @@
 @using Microsoft.AspNetCore.WebUtilities
-@using SPTarkov.Server.Web.Services
+@using SPTarkov.Server.Core.Models.Spt.Config
 @inject NavigationManager NavigationManager
+@inject HttpConfig HttpConfig
+@inject AuthService AuthService
 
 <div class="auth-page spt-page spt-page-centered">
     <MudPaper Elevation="0" Class="auth-box spt-panel pa-5">
@@ -20,6 +22,13 @@
             {
                 <MudAlert Severity="Severity.Error" Variant="Variant.Outlined" Dense="true">
                     @StatusMessage
+                </MudAlert>
+            }
+
+            @if (ShowForm && DefaultUserRequiresPasswordChange)
+            {
+                <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Dense="true">
+                    Default login: <b>@HttpConfig.WebAuthenticationConfig.DefaultUser.Username</b> / <b>@HttpConfig.WebAuthenticationConfig.DefaultUser.Password</b>
                 </MudAlert>
             }
 
@@ -61,6 +70,8 @@
 
     [Parameter]
     public string? FailureUrlOverride { get; set; }
+
+    private bool DefaultUserRequiresPasswordChange { get; set; }
 
     private bool HasLoginError { get; set; }
 
@@ -124,5 +135,7 @@
         var query = QueryHelpers.ParseQuery(uri.Query);
 
         HasLoginError = query.ContainsKey("authError");
+
+        DefaultUserRequiresPasswordChange = AuthService.DefaultUserRequiresPasswordChange();
     }
 }

--- a/Libraries/SPTushonka.Server.Web/Pages/ChangePassword.razor
+++ b/Libraries/SPTushonka.Server.Web/Pages/ChangePassword.razor
@@ -1,0 +1,168 @@
+@page "/change-password"
+
+@using Microsoft.AspNetCore.WebUtilities
+@using SPTarkov.Server.Web.Layout
+
+@layout BaseMudBlazorLayout
+
+@attribute [Authorize]
+
+@inject NavigationManager NavigationManager
+@inject AuthService AuthService
+@inject AuthenticationStateProvider AuthenticationStateProvider
+
+<div class="auth-page spt-page spt-page-centered">
+    <MudPaper Elevation="0" Class="auth-box spt-panel pa-5">
+        <MudStack Spacing="4">
+            <MudStack Row AlignItems="AlignItems.Center" Spacing="3">
+                <MudIcon Icon="@Icons.Material.Filled.LockReset"
+                         Color="Color.Warning"
+                         Size="Size.Large" />
+
+            <MudStack Spacing="1">
+                <MudText Typo="Typo.h5">Change password</MudText>
+                <MudText Typo="Typo.body2" Class="spt-muted">
+                    You must change the default password before continuing.
+                </MudText>
+            </MudStack>
+        </MudStack>
+
+        @if (!string.IsNullOrWhiteSpace(StatusMessage))
+        {
+            <MudAlert Severity="Severity.Error"
+                      Variant="Variant.Outlined"
+                      Dense="true">
+                @StatusMessage
+            </MudAlert>
+        }
+
+        <form class="auth-form"
+              @onsubmit="SubmitPasswordChange"
+              @onsubmit:preventDefault>
+
+            <label class="auth-field">
+                <span>New password</span>
+                <input name="newPassword"
+                       type="password"
+                       autocomplete="new-password"
+                       @bind="NewPassword"
+                       required
+                       autofocus />
+            </label>
+
+            <label class="auth-field">
+                <span>Confirm password</span>
+                <input name="confirmPassword"
+                       type="password"
+                       autocomplete="new-password"
+                       @bind="ConfirmPassword"
+                       required />
+            </label>
+
+            <button type="submit"
+                    class="auth-submit"
+                    disabled="@IsChanging">
+
+                @if (IsChanging)
+                {
+                    <MudProgressCircular Size="Size.Small"
+                                          Indeterminate="true" />
+                }
+                else
+                {
+                    <span>Change password</span>
+                    <MudIcon Icon="@Icons.Material.Filled.LockReset"
+                             Size="Size.Small" />
+                }
+            </button>
+        </form>
+    </MudStack>
+</MudPaper>
+</div>
+
+@code {
+    private string NewPassword { get; set; } = string.Empty;
+    private string ConfirmPassword { get; set; } = string.Empty;
+
+    private bool IsChanging { get; set; }
+    private string? StatusMessage { get; set; }
+
+    private string ReturnUrl { get; set; } = "/";
+
+    protected override void OnParametersSet()
+    {
+        var uri = NavigationManager.ToAbsoluteUri(NavigationManager.Uri);
+        var query = QueryHelpers.ParseQuery(uri.Query);
+
+        ReturnUrl = "/";
+
+        if (query.TryGetValue("returnUrl", out var returnUrl))
+        {
+            ReturnUrl = AuthService.GetSafeReturnUrl(returnUrl.ToString());
+        }
+
+        StatusMessage = null;
+
+        if (query.ContainsKey("passwordMismatch"))
+        {
+            StatusMessage = "The passwords do not match.";
+        }
+        else if (query.ContainsKey("passwordError"))
+        {
+            StatusMessage = "Unable to change your password.";
+        }
+    }
+
+    private async Task SubmitPasswordChange()
+    {
+        if (IsChanging)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(NewPassword))
+        {
+            StatusMessage = "Password is required.";
+            return;
+        }
+
+        if (NewPassword != ConfirmPassword)
+        {
+            StatusMessage = "The passwords do not match.";
+            return;
+        }
+
+        var authState = await AuthenticationStateProvider
+            .GetAuthenticationStateAsync();
+
+        var username = authState.User.Identity?.Name;
+
+        if (string.IsNullOrWhiteSpace(username))
+        {
+            StatusMessage = "Your authentication session has expired.";
+            return;
+        }
+
+        IsChanging = true;
+        StatusMessage = null;
+
+        try
+        {
+            var changed = await AuthService.TryChangeInitialPassword(
+                username,
+                NewPassword);
+
+            if (!changed)
+            {
+                StatusMessage = "Unable to change your password.";
+                return;
+            }
+
+            NavigationManager.NavigateTo(ReturnUrl, forceLoad: true);
+        }
+        finally
+        {
+            IsChanging = false;
+        }
+    }
+}

--- a/Libraries/SPTushonka.Server.Web/Pages/ChangePassword.razor.css
+++ b/Libraries/SPTushonka.Server.Web/Pages/ChangePassword.razor.css
@@ -1,0 +1,80 @@
+.auth-page {
+    padding: 24px;
+}
+
+.auth-box {
+    width: min(100%, 420px);
+}
+
+.auth-box.spt-panel {
+    border-color: rgba(63, 63, 70, 0.76);
+    background:
+        linear-gradient(180deg, rgba(24, 24, 27, 0.52), rgba(9, 9, 11, 0.78)),
+        var(--spt-surface);
+}
+
+.auth-form {
+    display: grid;
+    gap: 16px;
+}
+
+.auth-field {
+    display: grid;
+    gap: 8px;
+    color: var(--spt-text-muted);
+    font-size: 0.82rem;
+    font-weight: 700;
+}
+
+.auth-field input {
+    width: 100%;
+    min-height: 44px;
+    box-sizing: border-box;
+    border: 1px solid var(--spt-border-strong);
+    border-radius: var(--spt-radius);
+    background:
+        linear-gradient(180deg, rgba(3, 7, 18, 0.72), rgba(3, 7, 18, 0.58)),
+        rgba(3, 7, 18, 0.64);
+    color: var(--spt-text);
+    font: inherit;
+    font-size: 0.95rem;
+    font-weight: 600;
+    outline: none;
+    padding: 0 12px;
+}
+
+.auth-field input:focus {
+    border-color: var(--spt-info);
+    box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.16);
+}
+
+.auth-submit {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    min-height: 42px;
+    border: 1px solid rgba(250, 204, 21, 0.72);
+    border-radius: var(--spt-radius);
+    background: var(--spt-accent);
+    color: #111827;
+    cursor: pointer;
+    font: inherit;
+    font-weight: 800;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18);
+    transition:
+        background 140ms ease,
+        border-color 140ms ease,
+        transform 140ms ease,
+        box-shadow 140ms ease;
+}
+
+.auth-submit:hover,
+.auth-submit:focus-visible {
+    border-color: var(--spt-accent-strong);
+    background: var(--spt-accent-strong);
+    transform: translateY(-1px);
+    box-shadow:
+        0 12px 28px rgba(0, 0, 0, 0.24),
+        inset 0 1px 0 rgba(255, 255, 255, 0.2);
+}

--- a/Libraries/SPTushonka.Server.Web/SPTWeb.cs
+++ b/Libraries/SPTushonka.Server.Web/SPTWeb.cs
@@ -115,6 +115,7 @@ public static class SPTWeb
         app.MapControllers();
         app.MapPost(AuthService.LoginPath, HandleLogin).DisableAntiforgery();
         app.MapPost(AuthService.LogoutPath, HandleLogout).DisableAntiforgery();
+        app.MapPost(AuthService.ChangePasswordPath, HandleChangePassword).DisableAntiforgery();
         app.MapGet("/profiles/{profileId}/download", HandleProfileDownload).RequireAuthorization(AuthService.AdministratorPolicy);
 
         var razorBuilder = app.MapRazorComponents<App>().AddInteractiveServerRenderMode();
@@ -185,6 +186,7 @@ public static class SPTWeb
         var password = form["password"].ToString();
 
         var authenticatedUser = await authService.ValidateCredentialsAsync(username, password, context);
+
         if (authenticatedUser is null)
         {
             return Results.Redirect(AuthService.AddLoginError(failureUrl));
@@ -193,6 +195,50 @@ public static class SPTWeb
         await context.SignInAsync(
             AuthService.AuthenticationScheme,
             authenticatedUser,
+            new AuthenticationProperties { IsPersistent = true, AllowRefresh = true }
+        );
+
+        if (authenticatedUser.HasClaim(AuthService.MustChangePasswordClaimType, AuthService.MustChangePasswordClaimValue))
+        {
+            return Results.Redirect($"/change-password?returnUrl={Uri.EscapeDataString(returnUrl)}");
+        }
+
+        return Results.Redirect(returnUrl);
+    }
+
+    private static async Task<IResult> HandleChangePassword(HttpContext context, AuthService authService)
+    {
+        var form = await context.Request.ReadFormAsync();
+
+        var returnUrl = AuthService.GetSafeReturnUrl(form["returnUrl"].ToString());
+
+        var newPassword = form["newPassword"].ToString();
+        var confirmPassword = form["confirmPassword"].ToString();
+
+        if (newPassword != confirmPassword)
+        {
+            return Results.Redirect($"/change-password?returnUrl={Uri.EscapeDataString(returnUrl)}&passwordMismatch=1");
+        }
+
+        var username = context.User.Identity?.Name;
+
+        if (string.IsNullOrWhiteSpace(username))
+        {
+            return Results.Redirect(AuthService.GetLoginPageUrl(returnUrl));
+        }
+
+        var changed = await authService.TryChangeInitialPassword(username, newPassword);
+
+        if (!changed)
+        {
+            return Results.Redirect($"/change-password?returnUrl={Uri.EscapeDataString(returnUrl)}&passwordError=1");
+        }
+
+        var updatedUser = authService.CreateAuthenticatedPrincipal(username);
+
+        await context.SignInAsync(
+            AuthService.AuthenticationScheme,
+            updatedUser,
             new AuthenticationProperties { IsPersistent = true, AllowRefresh = true }
         );
 

--- a/Libraries/SPTushonka.Server.Web/Services/AuthService.cs
+++ b/Libraries/SPTushonka.Server.Web/Services/AuthService.cs
@@ -19,6 +19,10 @@ public class AuthService(ISptLogger<AuthService> logger, HttpConfig httpConfig, 
     internal const string IsAdministratorClaimType = "isAdministrator";
     internal const string IsAdministratorClaimValue = "true";
 
+    internal const string ChangePasswordPath = "/spt-web-auth/change-password";
+    internal const string MustChangePasswordClaimType = "mustChangePassword";
+    internal const string MustChangePasswordClaimValue = "true";
+
     internal IReadOnlyList<AuthUserCredential> Credentials
     {
         get { return _credentials.AsReadOnly(); }
@@ -49,7 +53,12 @@ public class AuthService(ISptLogger<AuthService> logger, HttpConfig httpConfig, 
     {
         var defaultUser = httpConfig.WebAuthenticationConfig.DefaultUser;
 
-        return CreatePrincipal(defaultUser.Username, defaultUser.IsAdministrator);
+        if (TryGetCredentials(defaultUser.Username, out var credential) && credential is not null)
+        {
+            return CreatePrincipal(credential.Username, credential.IsAdministrator, credential.MustChangePassword == true);
+        }
+
+        return CreatePrincipal(defaultUser.Username, defaultUser.IsAdministrator, false);
     }
 
     internal bool TryGetCredentials(string username, out AuthUserCredential? credential)
@@ -71,8 +80,29 @@ public class AuthService(ISptLogger<AuthService> logger, HttpConfig httpConfig, 
                 Username = username,
                 Password = passwordHasher.Hash(password),
                 IsAdministrator = isAdministrator,
+                MustChangePassword = false,
             }
         );
+        await SaveCredentials();
+
+        return true;
+    }
+
+    internal async Task<bool> TryChangeInitialPassword(string username, string newPassword)
+    {
+        if (!TryGetCredentials(username, out var credential) || credential is null)
+        {
+            return false;
+        }
+
+        if (credential.MustChangePassword != true)
+        {
+            return false;
+        }
+
+        credential.Password = passwordHasher.Hash(newPassword);
+        credential.MustChangePassword = false;
+
         await SaveCredentials();
 
         return true;
@@ -172,7 +202,7 @@ public class AuthService(ISptLogger<AuthService> logger, HttpConfig httpConfig, 
             }
         }
 
-        return CreatePrincipal(credentials.Username, credentials.IsAdministrator);
+        return CreatePrincipal(credentials.Username, credentials.IsAdministrator, credentials.MustChangePassword == true);
     }
 
     internal static string GetSafeReturnUrl(string? returnUrl)
@@ -207,7 +237,7 @@ public class AuthService(ISptLogger<AuthService> logger, HttpConfig httpConfig, 
         return $"{GetLoginPageUrl(returnUrl)}&noPermissions=1";
     }
 
-    private static ClaimsPrincipal CreatePrincipal(string username, bool isAdministrator)
+    private static ClaimsPrincipal CreatePrincipal(string username, bool isAdministrator, bool mustChangePassword)
     {
         var claims = new List<Claim> { new(ClaimTypes.Name, username), new(ClaimTypes.NameIdentifier, username) };
 
@@ -216,9 +246,24 @@ public class AuthService(ISptLogger<AuthService> logger, HttpConfig httpConfig, 
             claims.Add(new Claim(IsAdministratorClaimType, IsAdministratorClaimValue));
         }
 
+        if (mustChangePassword)
+        {
+            claims.Add(new Claim(MustChangePasswordClaimType, MustChangePasswordClaimValue));
+        }
+
         var identity = new ClaimsIdentity(claims, AuthenticationScheme);
 
         return new ClaimsPrincipal(identity);
+    }
+
+    internal ClaimsPrincipal? CreateAuthenticatedPrincipal(string username)
+    {
+        if (!TryGetCredentials(username, out var credential) || credential is null)
+        {
+            return null;
+        }
+
+        return CreatePrincipal(credential.Username, credential.IsAdministrator, credential.MustChangePassword == true);
     }
 
     private static bool IsLocalRequest(HttpContext httpContext)
@@ -257,12 +302,13 @@ public class AuthService(ISptLogger<AuthService> logger, HttpConfig httpConfig, 
                 ?? throw new NullReferenceException("Could not deserialize credentials.json");
 
             await MigratePlaintextCredentials();
+            await MigrateDefaultPasswordRequirement();
 
             return;
         }
 
-        // Seed from the config default user, hashing its plaintext password before it touches disk.
         var defaultUser = httpConfig.WebAuthenticationConfig.DefaultUser;
+
         _credentials =
         [
             new AuthUserCredential
@@ -270,8 +316,26 @@ public class AuthService(ISptLogger<AuthService> logger, HttpConfig httpConfig, 
                 Username = defaultUser.Username,
                 Password = passwordHasher.Hash(defaultUser.Password),
                 IsAdministrator = defaultUser.IsAdministrator,
+                MustChangePassword = true,
             },
         ];
+
+        await SaveCredentials();
+    }
+
+    private async Task MigrateDefaultPasswordRequirement()
+    {
+        var defaultUser = httpConfig.WebAuthenticationConfig.DefaultUser;
+
+        var credential = _credentials.FirstOrDefault(x => string.Equals(x.Username, defaultUser.Username, StringComparison.Ordinal));
+
+        if (credential is null || credential.MustChangePassword is not null)
+        {
+            return;
+        }
+
+        credential.MustChangePassword = DefaultUserRequiresPasswordChange();
+
         await SaveCredentials();
     }
 
@@ -296,6 +360,28 @@ public class AuthService(ISptLogger<AuthService> logger, HttpConfig httpConfig, 
             await SaveCredentials();
             logger.Warning($"Migrated {migratedCount} plaintext web credentials to hashes.");
         }
+    }
+
+    internal bool DefaultUserRequiresPasswordChange()
+    {
+        var defaultUser = httpConfig.WebAuthenticationConfig.DefaultUser;
+
+        if (!httpConfig.WebAuthenticationConfig.EnableDefaultUser)
+        {
+            return false;
+        }
+
+        if (!TryGetCredentials(defaultUser.Username, out var credential) || credential is null)
+        {
+            return false;
+        }
+
+        if (credential.MustChangePassword is not null)
+        {
+            return credential.MustChangePassword.Value;
+        }
+
+        return passwordHasher.Verify(defaultUser.Password, credential.Password, out _);
     }
 
     private async Task SaveCredentials(List<AuthUserCredential>? credentials = null)


### PR DESCRIPTION
Fresh install behaviour:
- credentials.json is created with default user requiring password change
- First authorize login will prompt (login shows default creds)
- Default user will not prompt again unless credentials.json is deleted

Existing install behaviour:
- Non default users will not prompt
- Default user with custom password will not prompt
- Default user with default password will prompt on first login (login shows default creds)
- Default user will not prompt again unless credentials.json is deleted (regardless of if they made the default user password spt again or custom)

This is also adjusted so the migration for the new model happens after the migration for plaintext passwords, so if they dont want to delete the credential.json but simply want to update the password in the file to plaintext they won't prompt again, it just hashes that password and then doesn't require a password change unless they flip the bool for the password change requirement to true.