### PR TITLE
Bundle Header Validation

### DIFF
--- a/Libraries/SPTushonka.Server.Assets/SPT_Data/database/locales/server/en.json
+++ b/Libraries/SPTushonka.Server.Assets/SPT_Data/database/locales/server/en.json
@@ -100,6 +100,7 @@
   "gameevent-bot_not_found": "addEventGearToScavs() - unable to find bot of type %s in database, skipping",
   "gameevent-no_gear_data": "No gear data in seasonalevents.json config for event %s",
   "gift-unable_to_handle_message_type_command": "Gift message type: %s not handled",
+  "git_lfs_bundle_error": "Attempted to load bundle %s but found a Git LFS pointer instead. If you're a developer, please ensure you've run a Git LFS pull.",
   "health-healing_item_not_found": "Unable to find healing item %s in player inventory",
   "health-unable_to_find_item_to_consume": "Unable to find consumable item %s in player inventory",
   "hideout-craft_has_undefined_progress_value_defaulting": "Hideout craft: %s has an undefined progress property value, defaulting to 0",

--- a/Libraries/SPTushonka.Server.Assets/SPT_Data/database/locales/server/en.json
+++ b/Libraries/SPTushonka.Server.Assets/SPT_Data/database/locales/server/en.json
@@ -100,7 +100,6 @@
   "gameevent-bot_not_found": "addEventGearToScavs() - unable to find bot of type %s in database, skipping",
   "gameevent-no_gear_data": "No gear data in seasonalevents.json config for event %s",
   "gift-unable_to_handle_message_type_command": "Gift message type: %s not handled",
-  "git_lfs_bundle_error": "Attempted to load bundle %s but found a Git LFS pointer instead. If you're a developer, please ensure you've run a Git LFS pull.",
   "health-healing_item_not_found": "Unable to find healing item %s in player inventory",
   "health-unable_to_find_item_to_consume": "Unable to find consumable item %s in player inventory",
   "hideout-craft_has_undefined_progress_value_defaulting": "Hideout craft: %s has an undefined progress property value, defaulting to 0",

--- a/Libraries/SPTushonka.Server.Core/Loaders/BundleLoader.cs
+++ b/Libraries/SPTushonka.Server.Core/Loaders/BundleLoader.cs
@@ -51,6 +51,7 @@ public sealed class BundleLoader(ISptLogger<BundleLoader> logger, JsonUtil jsonU
         var total = manifests.Sum(entry => entry.Entries.Count);
         var ok = 0;
         var missing = 0;
+        var invalid = 0;
 
         await AnsiConsole
             .Progress()
@@ -86,27 +87,36 @@ public sealed class BundleLoader(ISptLogger<BundleLoader> logger, JsonUtil jsonU
                             else
                             {
                                 var entry = await bundleHashCacheService.GetOrCalculateHashAsync(bundleLocalPath, ct);
-                                AddBundle(
-                                    bundleManifest.Key,
-                                    new BundleInfo
-                                    {
-                                        ModPath = relativeModPath,
-                                        Bundle = bundleManifest,
-                                        Crc = entry.Crc,
-                                        Size = entry.Size,
-                                        ModifiedUtcTicks = entry.ModifiedUtcTicks,
-                                    }
-                                );
-                                Interlocked.Increment(ref ok);
+
+                                if (entry is null)
+                                {
+                                    logger.Error($"Bundle {bundleManifest.Key} for mod {mod.ModMetadata.Name} is not a valid Unity asset bundle, skipping");
+                                    Interlocked.Increment(ref invalid);
+                                }
+                                else
+                                {
+                                    AddBundle(
+                                        bundleManifest.Key,
+                                        new BundleInfo
+                                        {
+                                            ModPath = relativeModPath,
+                                            Bundle = bundleManifest,
+                                            Crc = entry.Crc,
+                                            Size = entry.Size,
+                                            ModifiedUtcTicks = entry.ModifiedUtcTicks,
+                                        }
+                                    );
+                                    Interlocked.Increment(ref ok);
+                                }
                             }
 
                             progressTask.Increment(1);
-                            progressTask.Description = $"Loading bundles for {mod.ModMetadata.Name} (ok: {ok}, missing: {missing})";
+                            progressTask.Description = $"Loading bundles for {mod.ModMetadata.Name} (ok: {ok}, missing: {missing}, invalid: {invalid})";
                         }
                     );
                 }
 
-                progressTask.Description = $"Loaded bundles from {manifests.Count} mods (ok: {ok}, missing: {missing})";
+                progressTask.Description = $"Loaded bundles from {manifests.Count} mods (ok: {ok}, missing: {missing}, invalid: {invalid})";
             });
 
         await bundleHashCacheService.WriteCacheAsync(cancellationToken);

--- a/Libraries/SPTushonka.Server.Core/Services/Server/BundleHashCacheService.cs
+++ b/Libraries/SPTushonka.Server.Core/Services/Server/BundleHashCacheService.cs
@@ -1,15 +1,13 @@
 using System.Collections.Concurrent;
 using System.Text.Json;
 using SPTarkov.DI.Annotations;
-using SPTarkov.Server.Core.Exceptions.Database;
 using SPTarkov.Server.Core.Models.Spt.Bundles;
-using SPTarkov.Server.Core.Services.Locales;
 using SPTarkov.Server.Core.Utils;
 
 namespace SPTarkov.Server.Core.Services.Server;
 
 [Injectable(InjectionType.Singleton)]
-public sealed class BundleHashCacheService(JsonUtil jsonUtil, HashUtil hashUtil, FileUtil fileUtil, ServerLocalisationService serverLocalisationService)
+public sealed class BundleHashCacheService(JsonUtil jsonUtil, HashUtil hashUtil, FileUtil fileUtil)
 {
     private const string BundleHashCachePath = "./user/cache/";
     private const string CacheName = "bundleHashCache.json";
@@ -50,26 +48,28 @@ public sealed class BundleHashCacheService(JsonUtil jsonUtil, HashUtil hashUtil,
     /// <param name="cancellationToken">
     /// The <see cref="CancellationToken"/> that can be used to cancel the hashing operation.
     /// </param>
-    public async Task<BundleHashCacheEntry> GetOrCalculateHashAsync(string bundlePath, CancellationToken cancellationToken = default)
+    /// <returns>The cache entry, or null when the file is not a Unity asset bundle</returns>
+    public async Task<BundleHashCacheEntry?> GetOrCalculateHashAsync(string bundlePath, CancellationToken cancellationToken = default)
     {
         var fileInfo = new FileInfo(bundlePath);
         var size = fileInfo.Length;
         var modified = fileInfo.LastWriteTimeUtc.Ticks;
-        var fileStream = File.OpenRead(bundlePath);
 
         if (_loaded.TryGetValue(bundlePath, out var cached) && cached.Size == size && cached.ModifiedUtcTicks == modified)
         {
             _current[bundlePath] = cached;
-
-            if (!await fileUtil.VerifyBundleHeaderAsync(fileStream, cancellationToken))
-            {
-                await fileStream.DisposeAsync();
-                throw new ValidationErrorException(serverLocalisationService.GetText("validation_error_exception", bundlePath));
-            }
-
-            await fileStream.DisposeAsync();
             return cached;
         }
+
+        await using var fileStream = File.OpenRead(bundlePath);
+
+        if (!await fileUtil.VerifyBundleHeaderAsync(fileStream, cancellationToken))
+        {
+            return null;
+        }
+
+        // Reset stream position so the whole file is calculated
+        fileStream.Position = 0;
 
         var entry = new BundleHashCacheEntry
         {
@@ -77,8 +77,6 @@ public sealed class BundleHashCacheService(JsonUtil jsonUtil, HashUtil hashUtil,
             ModifiedUtcTicks = modified,
             Crc = await hashUtil.GenerateCrc32ForFileAsync(fileStream, cancellationToken),
         };
-
-        await fileStream.DisposeAsync();
 
         _current[bundlePath] = entry;
 

--- a/Libraries/SPTushonka.Server.Core/Services/Server/BundleHashCacheService.cs
+++ b/Libraries/SPTushonka.Server.Core/Services/Server/BundleHashCacheService.cs
@@ -76,6 +76,8 @@ public sealed class BundleHashCacheService(JsonUtil jsonUtil, HashUtil hashUtil,
             Crc = await hashUtil.GenerateCrc32ForFileAsync(fileStream, cancellationToken),
         };
 
+        await fileStream.DisposeAsync();
+
         _current[bundlePath] = entry;
 
         return entry;

--- a/Libraries/SPTushonka.Server.Core/Services/Server/BundleHashCacheService.cs
+++ b/Libraries/SPTushonka.Server.Core/Services/Server/BundleHashCacheService.cs
@@ -1,13 +1,15 @@
 using System.Collections.Concurrent;
 using System.Text.Json;
 using SPTarkov.DI.Annotations;
+using SPTarkov.Server.Core.Exceptions.Database;
 using SPTarkov.Server.Core.Models.Spt.Bundles;
+using SPTarkov.Server.Core.Services.Locales;
 using SPTarkov.Server.Core.Utils;
 
 namespace SPTarkov.Server.Core.Services.Server;
 
 [Injectable(InjectionType.Singleton)]
-public sealed class BundleHashCacheService(JsonUtil jsonUtil, HashUtil hashUtil, FileUtil fileUtil)
+public sealed class BundleHashCacheService(JsonUtil jsonUtil, HashUtil hashUtil, FileUtil fileUtil, ServerLocalisationService serverLocalisationService)
 {
     private const string BundleHashCachePath = "./user/cache/";
     private const string CacheName = "bundleHashCache.json";
@@ -53,10 +55,17 @@ public sealed class BundleHashCacheService(JsonUtil jsonUtil, HashUtil hashUtil,
         var fileInfo = new FileInfo(bundlePath);
         var size = fileInfo.Length;
         var modified = fileInfo.LastWriteTimeUtc.Ticks;
+        var fileStream = File.OpenRead(bundlePath);
 
         if (_loaded.TryGetValue(bundlePath, out var cached) && cached.Size == size && cached.ModifiedUtcTicks == modified)
         {
             _current[bundlePath] = cached;
+
+            if (!await fileUtil.VerifyBundleHeaderAsync(fileStream, cancellationToken))
+            {
+                throw new ValidationErrorException(serverLocalisationService.GetText("validation_error_exception", bundlePath));
+            }
+
             return cached;
         }
 
@@ -64,7 +73,7 @@ public sealed class BundleHashCacheService(JsonUtil jsonUtil, HashUtil hashUtil,
         {
             Size = size,
             ModifiedUtcTicks = modified,
-            Crc = await hashUtil.GenerateCrc32ForFileAsync(bundlePath, cancellationToken),
+            Crc = await hashUtil.GenerateCrc32ForFileAsync(fileStream, cancellationToken),
         };
 
         _current[bundlePath] = entry;

--- a/Libraries/SPTushonka.Server.Core/Services/Server/BundleHashCacheService.cs
+++ b/Libraries/SPTushonka.Server.Core/Services/Server/BundleHashCacheService.cs
@@ -63,9 +63,11 @@ public sealed class BundleHashCacheService(JsonUtil jsonUtil, HashUtil hashUtil,
 
             if (!await fileUtil.VerifyBundleHeaderAsync(fileStream, cancellationToken))
             {
+                await fileStream.DisposeAsync();
                 throw new ValidationErrorException(serverLocalisationService.GetText("validation_error_exception", bundlePath));
             }
 
+            await fileStream.DisposeAsync();
             return cached;
         }
 

--- a/Libraries/SPTushonka.Server.Core/Utils/FileUtil.cs
+++ b/Libraries/SPTushonka.Server.Core/Utils/FileUtil.cs
@@ -214,6 +214,14 @@ public sealed class FileUtil
         return Path.Combine(ModBasePath, modName);
     }
 
+    /// <summary>
+    ///     Check the first 32 bytes of a filestream to ensure they match a Unity AssetBundle
+    /// </summary>
+    /// <param name="fileStream">The file stream to check the header for</param>
+    /// <param name="cancellationToken">
+    ///     The <see cref="CancellationToken"/> that can be used to cancel the bundle header verification operation.
+    /// </param>
+    /// <returns>True if the header matches the AssetBundle header, false if not.</returns>
     public async Task<bool> VerifyBundleHeaderAsync(FileStream fileStream, CancellationToken cancellationToken = default)
     {
         var buffer = ArrayPool<byte>.Shared.Rent(_bundleMagicBytes.Length);

--- a/Libraries/SPTushonka.Server.Core/Utils/FileUtil.cs
+++ b/Libraries/SPTushonka.Server.Core/Utils/FileUtil.cs
@@ -214,7 +214,7 @@ public sealed class FileUtil
     }
 
     /// <summary>
-    ///     Check the first 32 bytes of a filestream to ensure they match a Unity AssetBundle
+    ///     Check the first 16 bytes of a filestream to ensure they match a Unity AssetBundle
     /// </summary>
     /// <param name="fileStream">The file stream to check the header for</param>
     /// <param name="cancellationToken">

--- a/Libraries/SPTushonka.Server.Core/Utils/FileUtil.cs
+++ b/Libraries/SPTushonka.Server.Core/Utils/FileUtil.cs
@@ -1,11 +1,13 @@
 using System.Buffers;
 using System.Text;
 using SPTarkov.DI.Annotations;
+using SPTarkov.Server.Core.Exceptions.Database;
+using SPTarkov.Server.Core.Services.Locales;
 
 namespace SPTarkov.Server.Core.Utils;
 
 [Injectable]
-public sealed class FileUtil
+public sealed class FileUtil(ServerLocalisationService serverLocalisationService)
 {
     private const string ModBasePath = "user/mods/";
 
@@ -16,6 +18,8 @@ public sealed class FileUtil
         0x78, 0x00, 0x32, 0x30, 0x32, 0x32, 0x2E, 0x33,
         0x2E, 0x34, 0x33, 0x66, 0x31, 0x00, 0x00, 0x00
     ];
+
+    private readonly byte[] _gitLfsBytes = [.. "version https://git-lfs.github.c"u8];
 
     public List<string> GetFiles(string path, bool recursive = false, string searchPattern = "*")
     {
@@ -234,15 +238,25 @@ public sealed class FileUtil
 
             var header = buffer.AsSpan(0, 32);
 
-            for (var i = 0; i < _bundleMagicBytes.Length; i++)
+            var isLfsPointer = true;
+            var isValidBundle = true;
+
+            for (var i = 0; i < 32; i++)
             {
-                if (header[i] != _bundleMagicBytes[i])
+                if (isLfsPointer && (i >= _gitLfsBytes.Length || header[i] != _gitLfsBytes[i]))
                 {
-                    return false;
+                    isLfsPointer = false;
                 }
+
+                if (isValidBundle && header[i] != _bundleMagicBytes[i])
+                {
+                    isValidBundle = false;
+                }
+
+                if (!isLfsPointer && !isValidBundle) { break; }
             }
 
-            return true;
+            return isLfsPointer ? throw new ValidationErrorException(serverLocalisationService.GetText("git_lfs_bundle_error", fileStream.Name)) : isValidBundle;
         }
         finally
         {

--- a/Libraries/SPTushonka.Server.Core/Utils/FileUtil.cs
+++ b/Libraries/SPTushonka.Server.Core/Utils/FileUtil.cs
@@ -1,13 +1,11 @@
 using System.Buffers;
 using System.Text;
 using SPTarkov.DI.Annotations;
-using SPTarkov.Server.Core.Exceptions.Database;
-using SPTarkov.Server.Core.Services.Locales;
 
 namespace SPTarkov.Server.Core.Utils;
 
 [Injectable]
-public sealed class FileUtil(ServerLocalisationService serverLocalisationService)
+public sealed class FileUtil
 {
     private const string ModBasePath = "user/mods/";
 

--- a/Libraries/SPTushonka.Server.Core/Utils/FileUtil.cs
+++ b/Libraries/SPTushonka.Server.Core/Utils/FileUtil.cs
@@ -10,7 +10,7 @@ public sealed class FileUtil
     private const string ModBasePath = "user/mods/";
 
     // [16] UnityFS.....5.x.
-    private readonly byte[] _bundleMagicBytes =
+    private static readonly byte[] BundleMagicBytes =
     [
         0x55, 0x6E, 0x69, 0x74, 0x79, 0x46, 0x53, 0x00,
         0x00, 0x00, 0x00, 0x08, 0x35, 0x2E, 0x78, 0x2E
@@ -223,29 +223,18 @@ public sealed class FileUtil
     /// <returns>True if the header matches the AssetBundle header, false if not.</returns>
     public async Task<bool> VerifyBundleHeaderAsync(FileStream fileStream, CancellationToken cancellationToken = default)
     {
-        var buffer = ArrayPool<byte>.Shared.Rent(_bundleMagicBytes.Length);
+        var buffer = ArrayPool<byte>.Shared.Rent(BundleMagicBytes.Length);
 
         try
         {
-            var read = await fileStream.ReadAsync(buffer.AsMemory(0, _bundleMagicBytes.Length), cancellationToken);
+            var read = await fileStream.ReadAtLeastAsync(
+                buffer.AsMemory(0, BundleMagicBytes.Length),
+                BundleMagicBytes.Length,
+                throwOnEndOfStream: false,
+                cancellationToken
+            );
 
-            if (read != 16) { return false; }
-
-            var header = buffer.AsSpan(0, 16);
-
-            var isValidBundle = true;
-
-            for (var i = 0; i < 16; i++)
-            {
-                if (isValidBundle && header[i] != _bundleMagicBytes[i])
-                {
-                    isValidBundle = false;
-                }
-
-                if (!isValidBundle) { break; }
-            }
-
-            return isValidBundle;
+            return read == BundleMagicBytes.Length && buffer.AsSpan(0, BundleMagicBytes.Length).SequenceEqual(BundleMagicBytes);
         }
         finally
         {

--- a/Libraries/SPTushonka.Server.Core/Utils/FileUtil.cs
+++ b/Libraries/SPTushonka.Server.Core/Utils/FileUtil.cs
@@ -11,15 +11,12 @@ public sealed class FileUtil(ServerLocalisationService serverLocalisationService
 {
     private const string ModBasePath = "user/mods/";
 
+    // [16] UnityFS.....5.x.
     private readonly byte[] _bundleMagicBytes =
     [
         0x55, 0x6E, 0x69, 0x74, 0x79, 0x46, 0x53, 0x00,
-        0x00, 0x00, 0x00, 0x08, 0x35, 0x2E, 0x78, 0x2E,
-        0x78, 0x00, 0x32, 0x30, 0x32, 0x32, 0x2E, 0x33,
-        0x2E, 0x34, 0x33, 0x66, 0x31, 0x00, 0x00, 0x00
+        0x00, 0x00, 0x00, 0x08, 0x35, 0x2E, 0x78, 0x2E
     ];
-
-    private readonly byte[] _gitLfsBytes = [.. "version https://git-lfs.github.c"u8];
 
     public List<string> GetFiles(string path, bool recursive = false, string searchPattern = "*")
     {
@@ -234,29 +231,23 @@ public sealed class FileUtil(ServerLocalisationService serverLocalisationService
         {
             var read = await fileStream.ReadAsync(buffer.AsMemory(0, _bundleMagicBytes.Length), cancellationToken);
 
-            if (read != 32) { return false; }
+            if (read != 16) { return false; }
 
-            var header = buffer.AsSpan(0, 32);
+            var header = buffer.AsSpan(0, 16);
 
-            var isLfsPointer = true;
             var isValidBundle = true;
 
-            for (var i = 0; i < 32; i++)
+            for (var i = 0; i < 16; i++)
             {
-                if (isLfsPointer && (i >= _gitLfsBytes.Length || header[i] != _gitLfsBytes[i]))
-                {
-                    isLfsPointer = false;
-                }
-
                 if (isValidBundle && header[i] != _bundleMagicBytes[i])
                 {
                     isValidBundle = false;
                 }
 
-                if (!isLfsPointer && !isValidBundle) { break; }
+                if (!isValidBundle) { break; }
             }
 
-            return isLfsPointer ? throw new ValidationErrorException(serverLocalisationService.GetText("git_lfs_bundle_error", fileStream.Name)) : isValidBundle;
+            return isValidBundle;
         }
         finally
         {

--- a/Libraries/SPTushonka.Server.Core/Utils/FileUtil.cs
+++ b/Libraries/SPTushonka.Server.Core/Utils/FileUtil.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Text;
 using SPTarkov.DI.Annotations;
 
@@ -7,6 +8,14 @@ namespace SPTarkov.Server.Core.Utils;
 public sealed class FileUtil
 {
     private const string ModBasePath = "user/mods/";
+
+    private readonly byte[] _bundleMagicBytes =
+    [
+        0x55, 0x6E, 0x69, 0x74, 0x79, 0x46, 0x53, 0x00,
+        0x00, 0x00, 0x00, 0x08, 0x35, 0x2E, 0x78, 0x2E,
+        0x78, 0x00, 0x32, 0x30, 0x32, 0x32, 0x2E, 0x33,
+        0x2E, 0x34, 0x33, 0x66, 0x31, 0x00, 0x00, 0x00
+    ];
 
     public List<string> GetFiles(string path, bool recursive = false, string searchPattern = "*")
     {
@@ -203,5 +212,33 @@ public sealed class FileUtil
     public string GetModPath(string modName)
     {
         return Path.Combine(ModBasePath, modName);
+    }
+
+    public async Task<bool> VerifyBundleHeaderAsync(FileStream fileStream, CancellationToken cancellationToken = default)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(_bundleMagicBytes.Length);
+
+        try
+        {
+            var read = await fileStream.ReadAsync(buffer.AsMemory(0, _bundleMagicBytes.Length), cancellationToken);
+
+            if (read != 32) { return false; }
+
+            var header = buffer.AsSpan(0, 32);
+
+            for (var i = 0; i < _bundleMagicBytes.Length; i++)
+            {
+                if (header[i] != _bundleMagicBytes[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
     }
 }

--- a/Libraries/SPTushonka.Server.Core/Utils/HashUtil.cs
+++ b/Libraries/SPTushonka.Server.Core/Utils/HashUtil.cs
@@ -22,22 +22,21 @@ public sealed class HashUtil(RandomUtil _randomUtil)
     /// <summary>
     /// Generates a CRC32 hash for a file, reading in chunks using a pooled buffer to reduce allocations.
     /// </summary>
-    /// <param name="filePath">The path to the file</param>
+    /// <param name="fileStream">The open file stream</param>
     /// <param name="cancellationToken">
     /// The <see cref="CancellationToken"/> that can be used to cancel the hashing operation.
     /// </param>
     /// <returns>The CRC32 hash as a uint</returns>
-    public async Task<uint> GenerateCrc32ForFileAsync(string filePath, CancellationToken cancellationToken = default)
+    public async Task<uint> GenerateCrc32ForFileAsync(FileStream fileStream, CancellationToken cancellationToken = default)
     {
         var crc = new Crc32();
-        await using var stream = File.OpenRead(filePath);
 
         // Rent from pool to avoid repeated allocations for each file read
         var buffer = ArrayPool<byte>.Shared.Rent(81920);
         try
         {
             int bytesRead;
-            while ((bytesRead = await stream.ReadAsync(buffer, cancellationToken)) > 0)
+            while ((bytesRead = await fileStream.ReadAsync(buffer, cancellationToken)) > 0)
             {
                 crc.Append(buffer.AsSpan(0, bytesRead));
             }


### PR DESCRIPTION
- Add VerifyBundleHeaderAsync
- Checks if the bundle header matches that of `UnityFS 5.x.x.2022.3.43f1` to validate its integrity.
- Change GenerateCrc32ForFileAsync to accept a FileStream instead of a path, so the bundle is only opened once in GetOrCalculateHashAsync