### PR TITLE
fix: correct inverted blacklist filter in TraderAssortExtensions.RemoveItemsFromAssort

### DIFF
--- a/Libraries/SPTushonka.Server.Core/Extensions/TraderAssortExtensions.cs
+++ b/Libraries/SPTushonka.Server.Core/Extensions/TraderAssortExtensions.cs
@@ -44,7 +44,7 @@ public static class TraderAssortExtensions
     public static void RemoveItemsFromAssort(this TraderAssort assortToFilter, HashSet<MongoId> itemsTplsToRemove)
     {
         assortToFilter.Items = assortToFilter
-            .Items.Where(item => item.ParentId == "hideout" && itemsTplsToRemove.Contains(item.Template))
+            .Items.Where(item => item.ParentId == "hideout" && !itemsTplsToRemove.Contains(item.Template))
             .ToList();
     }
 


### PR DESCRIPTION
﻿## Problem

`RemoveItemsFromAssort` is intended to remove blacklisted items from a trader's assort (per its XML doc comment "Given the blacklist provided, remove root items from assort"). However the `Where` predicate kept **only** the blacklisted items and removed every other root item:

```csharp
assortToFilter.Items = assortToFilter
    .Items.Where(item => item.ParentId == "hideout" && itemsTplsToRemove.Contains(item.Template))
    .ToList();
```

This inverts the intended filter: when a profile contains blacklisted items, the trader assort is emptied of all normal stock and only the banned items remain.

## Fix

Invert the `Contains` check so blacklisted items are excluded and normal stock is preserved:

```csharp
assortToFilter.Items = assortToFilter
    .Items.Where(item => item.ParentId == "hideout" && !itemsTplsToRemove.Contains(item.Template))
    .ToList();
```

## Verification

- `dotnet build --configuration Release` on SPTushonka.Server.Core: 0 errors
- Single-line change, scoped to one file
