### PR TITLE
fix(models): guard string.Intern against null in 8 setters

### DIFF
--- a/Libraries/SPTushonka.Server.Core/Models/Eft/Common/LocationBase.cs
+++ b/Libraries/SPTushonka.Server.Core/Models/Eft/Common/LocationBase.cs
@@ -784,7 +784,7 @@ public record ColliderParams
     public string? Parent
     {
         get { return field; }
-        set { field = string.Intern(value); }
+        set { field = value == null ? null : string.Intern(value); }
     }
 
     [JsonPropertyName("_props")]

--- a/Libraries/SPTushonka.Server.Core/Models/Eft/Common/LooseLoot.cs
+++ b/Libraries/SPTushonka.Server.Core/Models/Eft/Common/LooseLoot.cs
@@ -122,6 +122,6 @@ public record ComposedKey
     public string? Key
     {
         get { return field; }
-        set { field = string.Intern(value); }
+        set { field = value == null ? null : string.Intern(value); }
     }
 }

--- a/Libraries/SPTushonka.Server.Core/Models/Eft/Common/Tables/BotBase.cs
+++ b/Libraries/SPTushonka.Server.Core/Models/Eft/Common/Tables/BotBase.cs
@@ -176,7 +176,7 @@ public record Info
     public string? Side
     {
         get;
-        set { field = string.Intern(value); }
+        set { field = value == null ? null : string.Intern(value); }
     }
 
     public int? Level { get; set; }

--- a/Libraries/SPTushonka.Server.Core/Models/Eft/Common/Tables/Quest.cs
+++ b/Libraries/SPTushonka.Server.Core/Models/Eft/Common/Tables/Quest.cs
@@ -269,7 +269,7 @@ public record QuestCondition
     public required string ConditionType
     {
         get { return field; }
-        set { field = string.Intern(value); }
+        set { field = value == null ? null : string.Intern(value); }
     }
 
     [JsonPropertyName("epicGamesId")]

--- a/Libraries/SPTushonka.Server.Core/Models/Eft/Common/Tables/TemplateItem.cs
+++ b/Libraries/SPTushonka.Server.Core/Models/Eft/Common/Tables/TemplateItem.cs
@@ -18,7 +18,7 @@ public record TemplateItem
     public string? Name
     {
         get { return field; }
-        set { field = string.Intern(value); }
+        set { field = value == null ? null : string.Intern(value); }
     }
 
     [JsonPropertyName("_parent")]
@@ -38,7 +38,7 @@ public record TemplateItem
     public string? Prototype
     {
         get { return field; }
-        set { field = string.Intern(value); }
+        set { field = value == null ? null : string.Intern(value); }
     }
 
     /// <summary>
@@ -102,7 +102,7 @@ public record TemplateItemProperties
     public string? BackgroundColor
     {
         get { return field; }
-        set { field = string.Intern(value); }
+        set { field = value == null ? null : string.Intern(value); }
     }
 
     // Type confirmed via client
@@ -131,7 +131,7 @@ public record TemplateItemProperties
     public string? ItemSound
     {
         get { return field; }
-        set { field = string.Intern(value); }
+        set { field = value == null ? null : string.Intern(value); }
     }
 
     [JsonPropertyName("LeftHandItem")]


### PR DESCRIPTION
## Problem

8 model properties use `string.Intern(value)` in their setters without a null guard. When JSON deserialization passes an explicit `null` (or the value comes from an external source as null), `string.Intern(null)` throws `ArgumentNullException`, which fails the **entire JSON document deserialization** — a single null would crash loading of items/tasks/bots database or a mod's item package.

Sibling properties in the same files already guard against null (e.g. `TemplateItem.Type`, `BotBase.Nickname`), so these 8 are omissions:

- `BotBase.cs:179` — `Side`
- `TemplateItem.cs:21` — `Name`, `:41` — `Prototype`, `:105` — `BackgroundColor`, `:134` — `ItemSound`
- `Quest.cs:272` — `ConditionType`
- `LocationBase.cs:787` — `Parent` (ColliderParams record)
- `LooseLoot.cs:125` — `Key` (ComposedKey record)

## Fix

Apply the existing project pattern to all 8:

```csharp
set { field = value == null ? null : string.Intern(value); }
```

## Notes

- `Quest.cs:272` `ConditionType` is declared `required string` (non-nullable). The guard is still safer than a hard `ArgumentNullException` during deserialization; it trades a possible CS8601 warning for avoiding a crash.
- Un-guarded pattern count after fix: 0 (verified via grep).

## Verification

- `dotnet build --configuration Release` on SPTushonka.Server.Core: 0 errors (warnings 2836 → 2817)
