### PR TITLE
fix(loot): correct reward pool predicates in GetWeaponCrateRewardItems

### DIFF
--- a/Libraries/SPTushonka.Server.Core/Generators/Loot/LootGenerator.cs
+++ b/Libraries/SPTushonka.Server.Core/Generators/Loot/LootGenerator.cs
@@ -566,9 +566,9 @@ public class LootGenerator(
             var rewardItemPool = templateTable.Items.Values.Where(item =>
                 item.Parent == rewardKey
                 && string.Equals(item.Type, "item", StringComparison.OrdinalIgnoreCase)
-                && itemFilterService.IsItemBlacklisted(item.Id)
-                && !(containerSettings.AllowBossItems || itemFilterService.IsBossItem(item.Id))
-                && item.Properties.QuestItem is null
+                && !itemFilterService.IsItemBlacklisted(item.Id)
+                && (containerSettings.AllowBossItems || !itemFilterService.IsBossItem(item.Id))
+                && item.Properties.QuestItem != true
             );
 
             if (!rewardItemPool.Any())


### PR DESCRIPTION
## Problem

`GetWeaponCrateRewardItems` in LootGenerator.cs builds the sealed-weapon-crate reward pool with a Where predicate containing 3 transplant errors (lost negation / inverted logic on the TS→C# port), which in combination leave the pool effectively always empty.

Current (broken) predicate:

```csharp
var rewardItemPool = templateTable.Items.Values.Where(item =>
    item.Parent == rewardKey
    && string.Equals(item.Type, "item", StringComparison.OrdinalIgnoreCase)
    && itemFilterService.IsItemBlacklisted(item.Id)
    && !(containerSettings.AllowBossItems || itemFilterService.IsBossItem(item.Id))
    && item.Properties.QuestItem is null
);
```

1. `IsItemBlacklisted(item.Id)` — `ItemFilterService.IsItemBlacklisted` returns true when blacklisted, but the surrounding comment says "not globally blacklisted"; the `!` was lost, so the pool keeps only blacklisted items.
2. `!(containerSettings.AllowBossItems || itemFilterService.IsBossItem(item.Id))` — when `AllowBossItems` is true, `!(true || x)` is always false, emptying the pool entirely.
3. `item.Properties.QuestItem is null` — QuestItem is `bool?`; the items DB contains 0 nulls (4429 `false` + 148 `true`), so `is null` is always false, emptying the pool entirely.

## Fix

```csharp
var rewardItemPool = templateTable.Items.Values.Where(item =>
    item.Parent == rewardKey
    && string.Equals(item.Type, "item", StringComparison.OrdinalIgnoreCase)
    && !itemFilterService.IsItemBlacklisted(item.Id)
    && (containerSettings.AllowBossItems || !itemFilterService.IsBossItem(item.Id))
    && item.Properties.QuestItem != true
);
```

`QuestItem != true` keeps both `false` and `null` (normal items) and excludes `true` (quest items), matching the "not quest items" intent.

## Verification

- `dotnet build --configuration Release` on SPTushonka.Server.Core: 0 errors
- Single method, scoped to one file
