### PR TITLE
fix(quests): break repeatable-quest reward loop only when budget exhausted

### DIFF
--- a/Libraries/SPTushonka.Server.Core/Generators/RepeatableQuests/RepeatableQuestRewardGenerator.cs
+++ b/Libraries/SPTushonka.Server.Core/Generators/RepeatableQuests/RepeatableQuestRewardGenerator.cs
@@ -389,7 +389,10 @@ public class RepeatableQuestRewardGenerator(
             }
 
             // No budget for more items, end loop
-            break;
+            if (calculatedItemRewardBudget <= 0)
+            {
+                break;
+            }
         }
 
         return itemsToReturn;


### PR DESCRIPTION
## Problem

In `GetRewardableItemsFromPoolWithinBudget` (RepeatableQuestRewardGenerator.cs), the `for` loop that builds a reward list within a rouble budget has an **unconditional `break`** at the end of the loop body. The loop always exits after the first iteration, so repeatable-quest rewards contain only **1 item** regardless of `maxItemCount`/`RewardNumItems` config.

The comment says "No budget for more items, end loop" — the intent is to break only when the budget is exhausted, but the break runs on every iteration.

## Fix

Move the break into the budget-exhausted branch:

```csharp
// No budget for more items, end loop
if (calculatedItemRewardBudget <= 0)
{
    break;
}
```

The pool-empty break (line ~339) is preserved and remains correct.

## Verification

- `dotnet build --configuration Release` on SPTushonka.Server.Core: 0 errors
- Single method change, scoped to one file
