### PR TITLE
Fix circular reference in inventory

### DIFF
--- a/Libraries/SPTushonka.Server.Assets/SPT_Data/database/locales/server/en.json
+++ b/Libraries/SPTushonka.Server.Assets/SPT_Data/database/locales/server/en.json
@@ -136,6 +136,7 @@
   "insurance-unable_to_find_main_parent_for_attachment": "Could not find main-parent for insured attachment - ID: {{insuredItemId}}, Template: {{insuredItemTpl}}, Parent ID: {{parentId}}",
   "insurance-unable_to_find_parent_of_item": "Could not find parent for insured item - ID: {{insuredItemId}}, Template: {{insuredItemTpl}}, Parent ID: {{parentId}}",
   "insurance-unable_to_find_trader_by_id": "Trader: %s could not be found",
+  "inventory-corrupted_items_returned": "These items were found to be corrupted on client startup. Please collect them at your earliest convenience.",
   "inventory-edit_trader_item": "Unable to edit a traders item",
   "inventory-examine_item_does_not_exist": "examineItem() - No id with %s found",
   "inventory-fill_container_failed": "fillContainerMapWithItem() returned with an error %s",

--- a/Libraries/SPTushonka.Server.Core/Services/Commerce/PaymentService.cs
+++ b/Libraries/SPTushonka.Server.Core/Services/Commerce/PaymentService.cs
@@ -578,32 +578,41 @@ public class PaymentService(
     /// <returns> True if it's in inventory </returns>
     protected InventoryLocation GetItemLocation(MongoId itemId, List<Item> inventoryItems, MongoId playerStashId)
     {
-        var inventoryItem = inventoryItems.FirstOrDefault(item => item.Id == itemId);
-        if (inventoryItem is null)
+        var visited = new HashSet<MongoId>();
+        var currentId = itemId;
+
+        while (visited.Add(currentId))
         {
-            // Doesn't exist
-            return InventoryLocation.Other;
+            var inventoryItem = inventoryItems.FirstOrDefault(item => item.Id == currentId);
+            if (inventoryItem is null)
+            {
+                // Doesn't exist
+                return InventoryLocation.Other;
+            }
+
+            // is root item and its parent is the player stash
+            if (inventoryItem.Id == playerStashId)
+            {
+                return InventoryLocation.Stash;
+            }
+
+            // is child item and its parent is a root item
+            if (inventoryItem.SlotId == "hideout")
+            {
+                return InventoryLocation.Stash;
+            }
+
+            if (inventoryItem.SlotId == "SecuredContainer")
+            {
+                return InventoryLocation.Secure;
+            }
+
+            // Walk up to parentId
+            currentId = inventoryItem.ParentId;
         }
 
-        // is root item and its parent is the player stash
-        if (inventoryItem.Id == playerStashId)
-        {
-            return InventoryLocation.Stash;
-        }
-
-        // is child item and its parent is a root item
-        if (inventoryItem.SlotId == "hideout")
-        {
-            return InventoryLocation.Stash;
-        }
-
-        if (inventoryItem.SlotId == "SecuredContainer")
-        {
-            return InventoryLocation.Secure;
-        }
-
-        // Recursive call for parentId
-        return GetItemLocation(inventoryItem.ParentId, inventoryItems, playerStashId);
+        // circular reference detected, stop
+        return InventoryLocation.Other;
     }
 
     protected enum InventoryLocation

--- a/Libraries/SPTushonka.Server.Core/Services/Profile/ProfileFixerService.cs
+++ b/Libraries/SPTushonka.Server.Core/Services/Profile/ProfileFixerService.cs
@@ -14,6 +14,7 @@ using SPTarkov.Server.Core.Models.Enums;
 using SPTarkov.Server.Core.Models.Enums.Hideout;
 using SPTarkov.Server.Core.Models.Spt.Config;
 using SPTarkov.Server.Core.Models.Spt.Tables;
+using SPTarkov.Server.Core.Services.Commerce;
 using SPTarkov.Server.Core.Services.Locales;
 using SPTarkov.Server.Core.Utils;
 
@@ -32,7 +33,8 @@ public partial class ProfileFixerService(
     RewardHelper rewardHelper,
     HideoutHelper hideoutHelper,
     ServerLocalisationService serverLocalisationService,
-    CoreConfig coreConfig
+    CoreConfig coreConfig,
+    MailSendService mailSendService
 )
 {
     /// <summary>
@@ -46,6 +48,7 @@ public partial class ProfileFixerService(
         RemoveOrphanedQuests(pmcProfile);
         VerifyQuestProductionUnlocks(pmcProfile);
         FixOrphanedInsurance(pmcProfile);
+        CheckForAndFixCircularParentReferences(pmcProfile);
 
         if (pmcProfile.Hideout is not null)
         {
@@ -676,6 +679,122 @@ public partial class ProfileFixerService(
                 }
             }
         }
+    }
+
+    /// <summary>
+    ///     Detects items whose parent chain contains a circular reference and removes them from the
+    ///     inventory, mailing them back to the player rather than deleting them outright
+    /// </summary>
+    /// <param name="pmcProfile">Profile to check and repair</param>
+    public void CheckForAndFixCircularParentReferences(PmcData pmcProfile)
+    {
+        if (pmcProfile.Inventory?.Items is null || pmcProfile.Inventory.Stash is null)
+        {
+            return;
+        }
+
+        var items = pmcProfile.Inventory.Items;
+        var itemsById = items.ToDictionary(item => item.Id);
+        var stashId = pmcProfile.Inventory.Stash.Value;
+
+        var corruptedIds = new HashSet<MongoId>();
+        var confirmedGoodIds = new HashSet<MongoId>();
+
+        foreach (var item in items)
+        {
+            // root itself can't be part of a cycle
+            if (item.Id == stashId)
+            {
+                continue;
+            }
+
+            if (corruptedIds.Contains(item.Id) || confirmedGoodIds.Contains(item.Id))
+            {
+                continue;
+            }
+
+            var path = new List<MongoId>();
+            var pathSet = new HashSet<MongoId>();
+            var currentId = item.Id;
+            var hitCycle = false;
+
+            while (itemsById.TryGetValue(currentId, out var current))
+            {
+                if (confirmedGoodIds.Contains(currentId))
+                {
+                    // walked into a chain already proven fine, stop early
+                    break;
+                }
+
+                if (!pathSet.Add(currentId))
+                {
+                    // revisited a node on this path - circular reference
+                    hitCycle = true;
+                    break;
+                }
+
+                path.Add(currentId);
+
+                // same slots checked in PaymentService.GetItemLocation
+                if (currentId == stashId || current.SlotId == "hideout" || current.SlotId == "SecuredContainer")
+                {
+                    // Reached a legitimate root
+                    break;
+                }
+
+                if (current.ParentId is null)
+                {
+                    break;
+                }
+
+                currentId = current.ParentId;
+            }
+
+            var target = hitCycle ? corruptedIds : confirmedGoodIds;
+            foreach (var id in path)
+            {
+                target.Add(id);
+            }
+        }
+
+        // all good, return early
+        if (corruptedIds.Count == 0)
+        {
+            return;
+        }
+
+        logger.Warning(
+            $"Found {corruptedIds.Count} item(s) with circular parent references in profile: {pmcProfile.Id}. Removing and mailing back to player."
+        );
+
+        // create new item with a new instance id and break parent child relationship for safety
+        var itemsToMail = items
+            .Where(item => corruptedIds.Contains(item.Id))
+            .Select(item => new Item
+            {
+                Id = new MongoId(),
+                Template = item.Template,
+                Upd = item.Upd,
+            })
+            .ToList();
+
+        // remove all corrupted items as they will be mailed
+        pmcProfile.Inventory.Items.RemoveAll(item => corruptedIds.Contains(item.Id));
+
+        var sessionId = pmcProfile.SessionId;
+        if (sessionId is null)
+        {
+            logger.Warning($"Unable to mail corrupted items back to player, SessionId is null");
+
+            return;
+        }
+
+        // mail items to player
+        mailSendService.SendSystemMessageToPlayer(
+            sessionId.Value,
+            serverLocalisationService.GetText("inventory-corrupted_items_returned"),
+            itemsToMail
+        );
     }
 
     [GeneratedRegex("[^a-zA-Z0-9 -]")]


### PR DESCRIPTION
[6a77895bc6192842d018cd2c.json](https://github.com/user-attachments/files/31987365/6a77895bc6192842d018cd2c.json)

Attached profile is the one I used to test this PR. It's got a backpack that is a parent of itself (caused by a mod that was duplicating items on loot), I manually added a few roubles as a child of the backpack just to test children as well.

This PR adds:
Prevent infinite recursion when an item is parented to itself in the PaymentService
Profile Fixer method for client startup to detect recursive parents, detach all of the items from each other, remove all of them from the inventory, then mail them to the player with new IDs.

I'm not sure if we need to guard other containers? I used the same logic as the PaymentService for root detection