### PR TITLE
Don't remove entire stack on handover unless it takes the entire stack

### DIFF
--- a/Libraries/SPTushonka.Server.Core/Controllers/QuestController.cs
+++ b/Libraries/SPTushonka.Server.Core/Controllers/QuestController.cs
@@ -236,12 +236,19 @@ public class QuestController(
             }
 
             // Remove the right quantity of given items
-            var itemCountToRemove = Math.Min(itemHandover.Count ?? 0, handedInCount - totalItemCountToRemove);
+            var itemCountRequestedByClient = itemHandover.Count ?? 0;
+            var itemStackSize = matchingItemInProfile.GetItemStackSize();
+
+            var itemCountToRemove = Math.Min(Math.Min(itemCountRequestedByClient, itemStackSize), handedInCount - totalItemCountToRemove);
+
             totalItemCountToRemove += itemCountToRemove;
-            if (itemHandover.Count - itemCountToRemove > 0)
+
+            if (itemCountToRemove < itemStackSize)
             {
-                // Remove single item with no children
-                questHelper.ChangeItemStack(pmcData, itemHandover.Id, (int)(itemHandover.Count - itemCountToRemove), sessionID, output);
+                // Remove part of the stack, leaving the remainder in the inventory.
+                var remainingStackSize = itemStackSize - (int)itemCountToRemove;
+
+                questHelper.ChangeItemStack(pmcData, itemHandover.Id, remainingStackSize, sessionID, output);
 
                 // Complete - handedInCount == totalItemCountToRemove
                 if (Math.Abs(totalItemCountToRemove - handedInCount) < 0.01)


### PR DESCRIPTION
Tested multiple times with Therapist handover 250k quest

Will remove partial stack if needed, will remove multiple stacks if needed, and still functioned for handing over 3 healing items for the therapist quest after

Attached profile is at the handover stage:
[6aa217b590902f0a1c9af886.json](https://github.com/user-attachments/files/32034734/6aa217b590902f0a1c9af886.json)

